### PR TITLE
Use Optional's hash code method for Card

### DIFF
--- a/Module03/ca/mcgill/cs/swdesign/m3/demo/Card.java
+++ b/Module03/ca/mcgill/cs/swdesign/m3/demo/Card.java
@@ -88,8 +88,8 @@ public class Card
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + (aIsJoker ? 1231 : 1237);
-		result = prime * result + ((aRank == null) ? 0 : aRank.hashCode());
-		result = prime * result + ((aSuit == null) ? 0 : aSuit.hashCode());
+		result = prime * result + aRank.hashCode();
+		result = prime * result + aSuit.hashCode();
 		return result;
 	}
 


### PR DESCRIPTION
The hash code method of the `Card` class for module 3 performs nullability checks on `aRank` and `aSuit` before calling their hash code methods.
However, since `aRank` and `aSuit` are of type `Optional`, they should be invariant and not null. These nullability checks are unnecessary and won't fully be covered by any test.
We could rewrite those lines as follows for clarity:
```java
result = prime * result + ((aRank.isPresent()) ? 0 : aRank.hashCode());
result = prime * result + ((aSuit.isPresent()) ? 0 : aSuit.hashCode());
```
However, [`Optional#hashCode`](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#hashCode--) already performs this check, so it can be omitted.